### PR TITLE
Rebuild SYNCQT header files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# QtWebEngine Packaging
+
+This repository contains the packaging for [QtWebEngine](https://wiki.qt.io/QtWebEngine) for Ubuntu Touch.
+
+## Updating QtWebEngine version
+
+When updating QtWebEngine, be sure to visit [debian/rules](debian/rules) and update the `syncqt.pl` line to generate the SYNCQT headers for the new version of QtWebEngine.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# QtWebEngine Packaging
-
-This repository contains the packaging for [QtWebEngine](https://wiki.qt.io/QtWebEngine) for Ubuntu Touch.
-
-## Updating QtWebEngine version
-
-When updating QtWebEngine, be sure to visit [debian/rules](debian/rules) and update the `syncqt.pl` line to generate the SYNCQT headers for the new version of QtWebEngine.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtwebengine-opensource-src (5.11.2+dfsg-1ubports4) xenial; urgency=medium
+
+  * Rebuild SYNCQT headers during build
+
+ -- Dalton Durst <dalton@ubports.com>  Tue, 06 Nov 2018 14:52:28 -0600
+
 qtwebengine-opensource-src (5.11.2+dfsg-1ubports3) xenial; urgency=medium
 
   * Add back qtwebengine-no-gpu.patch since gpu seems not 100% yet

--- a/debian/rules
+++ b/debian/rules
@@ -78,6 +78,9 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	# Run qmake once to create .qmake.conf and be sure to append the following values.
 	qmake QT_BUILD_PARTS+=tests QMAKE_EXTRA_ARGS+="$(config_args)"
+	# Rebuild the SyncQt header files
+	rm -rf include/
+	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/syncqt.pl -version 5.11.2
 
 # Enable gstabs debugging symbols only on gstab_architectures.
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), $(gstab_architectures)))

--- a/debian/rules
+++ b/debian/rules
@@ -78,7 +78,7 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	# Run qmake once to create .qmake.conf and be sure to append the following values.
 	qmake QT_BUILD_PARTS+=tests QMAKE_EXTRA_ARGS+="$(config_args)"
-	# Rebuild the SyncQt header files
+	# Rebuild the SyncQt header files - update this on package updates
 	rm -rf include/
 	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/syncqt.pl -version 5.11.2
 

--- a/debian/rules
+++ b/debian/rules
@@ -78,9 +78,9 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	# Run qmake once to create .qmake.conf and be sure to append the following values.
 	qmake QT_BUILD_PARTS+=tests QMAKE_EXTRA_ARGS+="$(config_args)"
-	# Rebuild the SyncQt header files - update this on package updates
+	# Rebuild the SyncQt header files
 	rm -rf include/
-	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/syncqt.pl -version 5.11.2
+	/usr/lib/$(DEB_HOST_MULTIARCH)/qt5/bin/syncqt.pl -version $(DEB_VERSION_UPSTREAM:+dfsg=)
 
 # Enable gstabs debugging symbols only on gstab_architectures.
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), $(gstab_architectures)))


### PR DESCRIPTION
As suggested by @mitya57, rebuild the SYNCQT headers (the CamelCased ones) prior to the build of QtWebEngine.

Fixes #6!